### PR TITLE
Remove packaging of npm in focal

### DIFF
--- a/packages.toml
+++ b/packages.toml
@@ -88,6 +88,7 @@ blocked-distros = ["focal", "jammy", "bullseye"]
 [nodejs]
 
 [npm]
+blocked-distros = ["focal"]
 
 [parse-changelog]
 


### PR DESCRIPTION
This Ubuntu is too old for the way this package is built:

```
[#] Starting build()...
node bin/npm-cli.js run resetdeps
ERROR: npm is known not to run on Node.js v10.19.0
You'll need to upgrade to a newer Node.js version in order to use this
version of npm. You can find the latest version at https://nodejs.org/
make: *** [Makefile:52: deps] Error 1
[! build()] A failure occurred in build().
    Aborting...
Error: Process completed with exit code 4.
```