### PR TITLE
Package Update: `deno`

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Hunter Wittenborn <hunter@hunterwittenborn.com>
 pkgname=deno
-pkgver=1.45.3
+pkgver=1.45.4
 pkgrel=1
 pkgdesc='A modern runtime for JavaScript and TypeScript'
 arch=('any')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Hunter Wittenborn <hunter@hunterwittenborn.com>
 pkgname=deno
-pkgver=1.45.2
+pkgver=1.45.3
 pkgrel=1
 pkgdesc='A modern runtime for JavaScript and TypeScript'
 arch=('any')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Hunter Wittenborn <hunter@hunterwittenborn.com>
 pkgname=deno
-pkgver=1.44.4
+pkgver=1.45.0
 pkgrel=1
 pkgdesc='A modern runtime for JavaScript and TypeScript'
 arch=('any')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Hunter Wittenborn <hunter@hunterwittenborn.com>
 pkgname=deno
-pkgver=1.44.3
+pkgver=1.44.4
 pkgrel=1
 pkgdesc='A modern runtime for JavaScript and TypeScript'
 arch=('any')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Hunter Wittenborn <hunter@hunterwittenborn.com>
 pkgname=deno
-pkgver=1.25.0
+pkgver=1.44.2
 pkgrel=1
 pkgdesc='A modern runtime for JavaScript and TypeScript'
 arch=('any')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Hunter Wittenborn <hunter@hunterwittenborn.com>
 pkgname=deno
-pkgver=1.45.1
+pkgver=1.45.2
 pkgrel=1
 pkgdesc='A modern runtime for JavaScript and TypeScript'
 arch=('any')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,10 +1,10 @@
 # Maintainer: Hunter Wittenborn <hunter@hunterwittenborn.com>
 pkgname=deno
 pkgver=1.44.2
-pkgrel=1
+pkgrel=3
 pkgdesc='A modern runtime for JavaScript and TypeScript'
 arch=('any')
-makedepends=('cargo' 'git')
+makedepends=('cargo' 'cmake' 'git' 'protobuf-compiler')
 url='https://deno.land'
 license=('MIT')
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Hunter Wittenborn <hunter@hunterwittenborn.com>
 pkgname=deno
-pkgver=1.44.2
-pkgrel=3
+pkgver=1.44.3
+pkgrel=1
 pkgdesc='A modern runtime for JavaScript and TypeScript'
 arch=('any')
 makedepends=('cargo' 'cmake' 'git' 'protobuf-compiler')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Hunter Wittenborn <hunter@hunterwittenborn.com>
 pkgname=deno
-pkgver=1.45.4
+pkgver=1.45.5
 pkgrel=1
 pkgdesc='A modern runtime for JavaScript and TypeScript'
 arch=('any')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Hunter Wittenborn <hunter@hunterwittenborn.com>
 pkgname=deno
-pkgver=1.45.0
+pkgver=1.45.1
 pkgrel=1
 pkgdesc='A modern runtime for JavaScript and TypeScript'
 arch=('any')


### PR DESCRIPTION
The following distros have updates available:
- `ubuntu-focal:amd64`
- `ubuntu-focal:arm64`
- `ubuntu-jammy:amd64`
- `ubuntu-jammy:arm64`
- `ubuntu-lunar:amd64`
- `ubuntu-lunar:arm64`
- `ubuntu-mantic:amd64`
- `ubuntu-mantic:arm64`
- `ubuntu-noble:amd64`
- `ubuntu-noble:arm64`
- `debian-bullseye:amd64`
- `debian-bullseye:arm64`
- `debian-bookworm:amd64`
- `debian-bookworm:arm64`

Depending on previously failed builds or newly added distros, there may not be any file changes in this PR. If, however, this information doesn't appear to be correct, please reach out to a Prebuilt-MPR team member.