### PR TITLE
Package Update: `just`

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Hunter Wittenborn <hunter@hunterwittenborn.com>
 pkgname=just
-pkgver=1.28.0
+pkgver=1.29.0
 pkgrel=1
 pkgdesc='Just a command runner'
 arch=('any')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Hunter Wittenborn <hunter@hunterwittenborn.com>
 pkgname=just
-pkgver=1.29.0
+pkgver=1.29.1
 pkgrel=1
 pkgdesc='Just a command runner'
 arch=('any')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Hunter Wittenborn <hunter@hunterwittenborn.com>
 pkgname=just
-pkgver=1.27.0
+pkgver=1.28.0
 pkgrel=1
 pkgdesc='Just a command runner'
 arch=('any')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Hunter Wittenborn <hunter@hunterwittenborn.com>
 pkgname=just
-pkgver=1.29.1
-pkgrel=2
+pkgver=1.30.1
+pkgrel=1
 pkgdesc='Just a command runner'
 arch=('any')
 makedepends=('cargo>=1.63')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Hunter Wittenborn <hunter@hunterwittenborn.com>
 pkgname=just
 pkgver=1.29.1
-pkgrel=1
+pkgrel=2
 pkgdesc='Just a command runner'
 arch=('any')
 makedepends=('cargo>=1.63')
@@ -19,8 +19,8 @@ build() {
 package() {
     cd "${pkgname}-${pkgver}/"
     install -Dm 755 "target/release/${pkgname}" "${pkgdir}/usr/bin/${pkgname}"
-    install -Dm 644 "completions/${pkgname}.bash" "${pkgdir}/usr/share/bash-completion/completions/just"
-    install -Dm 644 "man/${pkgname}.1" "${pkgdir}/usr/share/man/man1/${pkgname}.1"
+    "target/release/${pkgname}" --completions bash | install -Dm 644 /dev/stdin "${pkgdir}/usr/share/bash-completion/completions/just"
+    "target/release/${pkgname}" --man | install -Dm 644 /dev/stdin "${pkgdir}/usr/share/man/man1/${pkgname}.1"
 }
 
 # vim: set sw=4 expandtab:


### PR DESCRIPTION
The following distros have updates available:
- `ubuntu-focal:amd64`
- `ubuntu-focal:arm64`
- `ubuntu-jammy:amd64`
- `ubuntu-jammy:arm64`
- `ubuntu-lunar:amd64`
- `ubuntu-lunar:arm64`
- `ubuntu-mantic:amd64`
- `ubuntu-mantic:arm64`
- `ubuntu-noble:amd64`
- `ubuntu-noble:arm64`
- `debian-bullseye:amd64`
- `debian-bullseye:arm64`
- `debian-bookworm:amd64`
- `debian-bookworm:arm64`

Depending on previously failed builds or newly added distros, there may not be any file changes in this PR. If, however, this information doesn't appear to be correct, please reach out to a Prebuilt-MPR team member.