### PR TITLE
Package Update: `matrix-commander-rs`

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,10 +1,11 @@
 # Maintainer: Hunter Wittenborn <hunter@hunterwittenborn.com>
 pkgname=matrix-commander-rs
 pkgver=0.1.24
-pkgrel=2
+pkgrel=3
 pkgdesc='Simple but convenient CLI-based Matrix client app'
 arch=('any')
-makedepends=('cargo')
+depends=('libssl3')
+makedepends=('cargo' 'libssl-dev' 'pkg-config')
 license=('GPL-3.0')
 url='https://github.com/8go/matrix-commander-rs'
 


### PR DESCRIPTION
The following distros have updates available:
- `ubuntu-focal:amd64`
- `ubuntu-focal:arm64`
- `ubuntu-jammy:amd64`
- `ubuntu-jammy:arm64`
- `ubuntu-lunar:amd64`
- `ubuntu-lunar:arm64`
- `ubuntu-mantic:amd64`
- `ubuntu-mantic:arm64`
- `ubuntu-noble:amd64`
- `ubuntu-noble:arm64`
- `debian-bullseye:amd64`
- `debian-bullseye:arm64`
- `debian-bookworm:amd64`
- `debian-bookworm:arm64`

Depending on previously failed builds or newly added distros, there may not be any file changes in this PR. If, however, this information doesn't appear to be correct, please reach out to a Prebuilt-MPR team member.