### PR TITLE
Package Update: `nodejs`

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,20 +1,26 @@
 # Maintainer: Hunter Wittenborn <hunter@hunterwittenborn.com>
 _pkgname='node'
 pkgname=nodejs
-pkgver=18.8.0
-pkgrel=2
+pkgver=20.15.0
+pkgrel=1
 pkgdesc='Node.js JavaScript runtime'
 arch=('any')
 depends=(
+    'libbrotli1'
+    'libcares2'
+    'libnghttp2-14'
+    'libuv1t64'
+    'libssl3t64'
+    'zlib1g'
+)
+makedepends=(
+    'g++'
     'libbrotli-dev'
     'libc-ares-dev'
     'libnghttp2-dev'
     'libuv1-dev'
     'libssl-dev'
     'zlib1g-dev'
-)
-makedepends=(
-    'g++'
     'ninja-build'
     'python3'
 )


### PR DESCRIPTION
The following distros have updates available:
- `ubuntu-focal:amd64`
- `ubuntu-focal:arm64`
- `ubuntu-jammy:amd64`
- `ubuntu-jammy:arm64`
- `ubuntu-lunar:amd64`
- `ubuntu-lunar:arm64`
- `ubuntu-mantic:amd64`
- `ubuntu-mantic:arm64`
- `ubuntu-noble:amd64`
- `ubuntu-noble:arm64`
- `debian-bullseye:amd64`
- `debian-bullseye:arm64`
- `debian-bookworm:amd64`
- `debian-bookworm:arm64`

Depending on previously failed builds or newly added distros, there may not be any file changes in this PR. If, however, this information doesn't appear to be correct, please reach out to a Prebuilt-MPR team member.