### PR TITLE
Package Update: `prismlauncher-qt5`

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,100 @@
+# Maintainer: lordpipe <lordpipe@protonmail.com>
+# Contributor: Sefa Eyeoglu <conctact@scrumplex.net>
+# Contributor: dada513 <dada513@protonmail.com>
+
+pkgname=prismlauncher-qt5
+pkgver=8.4
+pkgrel=1
+pkgdesc='Minecraft launcher with ability to manage multiple instances.'
+arch=('i386' 'amd64' 'arm64' 'armhf' 'riscv64')
+url='https://prismlauncher.org'
+license=('GPL-3')
+depends=('libqt5svg5' 'qt5-image-formats-plugins' 'libqt5xml5' 'libqt5core5a' 'libqt5network5' 'libqt5gui5')
+makedepends=('scdoc' 'extra-cmake-modules' 'cmake' 'git' 'openjdk-17-jdk' 'zlib1g-dev' 'libgl1-mesa-dev' 'qtbase5-dev' 'qtchooser' 'qt5-qmake' 'qtbase5-dev-tools' 'gcc' 'g++')
+optdepends=('java-runtime=21: support for Minecraft versions >= 1.20.5'
+            's!java-runtime=17: support for Minecraft versions >= 1.17 and <= 1.20.4'
+            's!java-runtime=8: support for Minecraft versions <= 1.16'
+            's!gamemode: support for GameMode'
+            's!mangohud: HUD overlay for FPS and temperatures'
+            's!flite: narrator support'
+            's!x11-xserver-utils: xrandr is needed to support Minecraft versions <= 1.12')
+source=("https://github.com/PrismLauncher/PrismLauncher/releases/download/$pkgver/PrismLauncher-$pkgver.tar.gz"
+        'gcc-armv7-fix.patch'
+        'copyright')
+sha256sums=('a4df9059559df2e410ddf933e05fe4bffaa01631c6eeb55e63af4a2d0d719726'
+            '42394447d4b52c9329ff45f3c700c0eb2090a5803c5de010587d64294c37420f'
+            '55f14ca1c20ba05785b248b3454ce2671149112d6b7c1a4e4fd24f4dde8f4c71')
+postinst=postinst.sh
+
+# allow for ARM support
+#TODO: makedeb's hard-coding for x86-64 has been fixed in a future makedeb version
+#TODO: these 8 lines make this script match the behavior of future makedeb. When it releases, remove this
+CARCH="$(dpkg --print-architecture)"
+CHOST="$(uname -m)-pc-linux-gnu"
+CFLAGS=${CFLAGS/-march=x86-64/}
+CXXFLAGS=${CXXFLAGS/-march=x86-64/}
+CFLAGS=${CFLAGS/-mtune=generic/}
+CXXFLAGS=${CXXFLAGS/-mtune=generic/}
+CFLAGS=${CFLAGS/-fcf-protection/}
+CXXFLAGS=${CXXFLAGS/-fcf-protection/}
+
+# if the user hasn't specified a tuning/architecture, specify our own minimal defaults to cover the earliest CPUs
+if [[ ${CFLAGS} != *"-mtune"* && ${CFLAGS} != *"-march"* ]]; then
+    case "$CARCH" in
+        amd64)
+            CFLAGS+=" -march=x86-64 -fcf-protection"
+            CXXFLAGS+=" -march=x86-64 -fcf-protection"
+            ;;
+        i386)
+            CFLAGS+=" -march=i686"
+            CXXFLAGS+=" -march=i686"
+            ;;
+        arm64)
+            CFLAGS+=" -march=armv8-a"
+            CXXFLAGS+=" -march=armv8-a"
+            ;;
+        armhf)
+            CFLAGS+=" -march=armv7-a+fp"
+            CXXFLAGS+=" -march=armv7-a+fp"
+            ;;
+        riscv64)
+            CFLAGS+=" -march=rv64imafdc"
+            CXXFLAGS+=" -march=rv64imafdc"
+            ;;
+    esac
+fi
+
+prepare() {
+    # workaround https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64860
+    # more info: https://github.com/PrismLauncher/PrismLauncher/issues/128
+    if [[ "$(uname -m)" = armv7* ]]; then
+        echo "GCC / ARMv7 fix is needed for this architecture, applying gcc-armv7-fix.patch"
+        patch --directory="PrismLauncher-$pkgver" --forward --strip=1 --input="${srcdir}/gcc-armv7-fix.patch"
+    else
+        echo "GCC / ARMv7 fix is not needed for this architecture, skipping gcc-armv7-fix.patch"
+    fi
+}
+
+build() {
+    cd "${srcdir}/PrismLauncher-$pkgver"
+    cmake -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX="/usr" \
+          -DLauncher_BUILD_PLATFORM="debian" \
+          -DLauncher_APP_BINARY_NAME="${pkgname}" \
+          -DLauncher_QT_VERSION_MAJOR=5 \
+          -DENABLE_LTO=ON \
+          -Bbuild -S.
+    cmake --build build
+}
+
+check() {
+    cd "${srcdir}/PrismLauncher-$pkgver/build"
+    ctest . -E Task  # Skip unreliable Task test
+}
+
+package() {
+    cd "${srcdir}/PrismLauncher-$pkgver/build"
+    DESTDIR="$pkgdir" cmake --install .
+    mkdir -p "${pkgdir}/usr/share/doc/$pkgname"
+    cp -v "${srcdir}/copyright" "${pkgdir}/usr/share/doc/$pkgname/copyright"
+}

--- a/copyright
+++ b/copyright
@@ -1,0 +1,358 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: prismlauncher
+Source: https://github.com/PrismLauncher/PrismLauncher/
+
+Files: *
+Copyright: 2022-2023, Prism Launcher Contributors
+           2021-2022, PolyMC Contributors
+           2013-2021, MultiMC Contributors
+           2013-2021, Petr Mrazek <peterix@gmail.com>
+License: GPL-3 and Apache-2.0
+
+Files: libraries/libnbtplusplus/*
+Copyright: 2022-2023, Prism Launcher Contributors
+           2021-2022, PolyMC Contributors
+           2013-2021, MultiMC Contributors
+           2013-2021, Petr Mrazek <peterix@gmail.com>
+License: LGPL-3
+
+Files: libraries/libnbtplusplus/*
+Copyright: 2022-2023, Prism Launcher Contributors
+           2021-2022, PolyMC Contributors
+           2013-2021, MultiMC Contributors
+           2013-2021, Petr Mrazek <peterix@gmail.com>
+License: LGPL-3
+
+Files: libraries/rainbow
+Copyright: 2015, MultiMC Contributors
+           2015, Petr Mrazek <peterix@gmail.com>
+           2007, KDE Contributors
+           2007, Matthew Woehlke <mw_triad@users.sourceforge.net>
+           2007, Olaf Schmidt <ojschmidt@kde.org>
+           2007, Thomas Zander <zander@kde.org>
+           2007, Zack Rusin <zack@kde.org>
+License: LGPL-2
+
+Files: libraries/cmark/*
+Copyright: 2014-2023, cmark Contributors
+           2014, John MacFarlane
+License: BSD-2-clause
+ 
+Files: libraries/gamemode
+Copyright: 2017-2022, Feral Interactive
+License: BSD-3-clause
+
+Files: libraries/filesystem
+Copyright: 2018, Steffen Schümann <s.schuemann@pobox.com>
+License: Expat
+
+Files: libraries/quazip
+Copyright: 2005-2021, Sergey A. Tachenov
+           2002, MiniZip contributors
+           2002, Gilles Vollant
+License: LGPL-2.1
+
+Files: libraries/systeminfo
+Copyright: 2018, MultiMC Contributors
+           2018, Petr Mrazek <peterix@gmail.com>
+           2017, Nate Coraor
+
+Files:
+ libraries/tomlplusplus
+Copyright: 2019-2023, Mark Gillard <mark.gillard@outlook.com.au>
+           2019-2023, tomlplusplus Contributors
+License: Expat
+
+Files:
+ launcher/resources/*
+Copyright: 2022-2023, Prism Launcher Contributors
+           2021-2022, PolyMC Contributors
+           2014-2023, KDE Contributors
+           2014, Austin Andrews
+           2013-2021, MultiMC Contributors
+           2014, Uri Herrera <uri_herrera@nitrux.in>
+           2012, Adam Whitcroft
+           2007, Nuno Pinheiro <nuno@oxygen-icons.org>
+           2007, David Vignoni <david@icon-king.com>
+           2007. David Miller <miller@oxygen-icons.org>
+           2007, Johann Ollivier Lapeyre <johann@oxygen-icons.org>
+           2007, Kenneth Wimer <kwwii@bootsplash.org>
+           2007, Riccardo Iaconelli <riccardo@oxygen-icons.org>
+License: GPL-3 and CC0 and OFL-1.1
+Comment:
+ The launcher/resources directory contains files from many sources.
+
+Copyright: 2014, Austin Andrews (http://materialdesignicons.com/)
+Copyright (c) 2014, Google (http://www.google.com/design/)
+uses the license at https://github.com/google/material-design-icons/blob/master/LICENSE
+
+Files:
+ debian/*
+Copyright: 2023, lordpipe <lordpipe@protonmail.com>
+           2022, Sefa Eyeoglu <conctact@scrumplex.net>
+           2022, dada513 <dada513@protonmail.com>
+License: permissive
+ Copying and distribution of this package, with or without modification,
+ are permitted in any medium without royalty provided the copyright notice
+ and this notice are preserved.
+
+License: GPL-3
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, version 3 of the License.
+ .
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+Comment:
+ On Debian systems, the full text of the GNU General Public License
+ version 3 can be found in the file /usr/share/common-licenses/GPL-3.
+
+License: Apache-2.0
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ .
+     http://www.apache.org/licenses/LICENSE-2.0
+ .
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+Comment:
+ On Debian systems, the full text of the Apache License version 2 can
+ be found in /usr/share/common-licenses/Apache-2.0.
+
+License: LGPL-3
+ This library is free software; you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License Version 3.0 as published by
+ the Free Software Foundation.
+ .
+ This library is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ details.
+ .
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+Comment:
+ On Debian systems, the complete text of the GNU Lesser General Public License
+ can be found in `/usr/share/common-licenses/LGPL-3'
+
+License: LGPL-2
+ This package is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License version 2 as published by the Free Software Foundation.
+ .
+ This package is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+ .
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+Comment:
+ On Debian systems, the complete text of the GNU Lesser General
+ Public License can be found in `/usr/share/common-licenses/LGPL-2’.
+
+License: LGPL-2.1
+ This package is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License version 2.1 as published by the Free Software Foundation.
+ .
+ This package is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ Lesser General Public License for more details.
+ .
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+Comment:
+ On Debian systems, the complete text of the GNU Lesser General
+ Public License can be found in `/usr/share/common-licenses/LGPL-2.1'.
+
+License: BSD-2-clause
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice(s), this list of conditions and the following disclaimer as
+    the first lines of this file unmodified other than the possible
+    addition of one or more copyright notices.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice(s), this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) ``AS IS'' AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER(S) BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE
+ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+License: BSD-3-clause
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ .
+ 1. Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+ .
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+ .
+ 3. Neither the name of the copyright holder nor the names of its contributors
+    may be used to endorse or promote products derived from this software
+    without specific prior written permission.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+License: Expat
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+ .
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT
+ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+License: CC0
+ To the extent possible under law, the author(s) have dedicated all
+ copyright and related and neighboring rights to this software to
+ the public domain worldwide. This software is distributed without
+ any warranty.
+ .
+ You should have received a copy of the CC0 Public Domain Dedication
+ along with this software. If not, see
+ <http://creativecommons.org/publicdomain/zero/1.0/>.
+Comment:
+ On Debian systems, the complete text of the CC0 1.0 Universal license can be
+ found in '/usr/share/common-licenses/CC0-1.0'.
+
+License:   SIL-1.1
+ This Font Software is licensed under the SIL Open Font License,
+ Version 1.1.
+ .
+ This license is copied below, and is also available with a FAQ at:
+ http://scripts.sil.org/OFL
+ .
+ -----------------------------------------------------------
+ SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+ -----------------------------------------------------------
+ PREAMBLE
+ .
+ The goals of the Open Font License (OFL) are to stimulate worldwide
+ development of collaborative font projects, to support the font
+ creation efforts of academic and linguistic communities, and to provide
+ a free and open framework in which fonts may be shared and improved in
+ partnership with others.
+ .
+ The OFL allows the licensed fonts to be used, studied, modified and
+ redistributed freely as long as they are not sold by themselves. The
+ fonts, including any derivative works, can be bundled, embedded,
+ redistributed and/or sold with any software provided that any reserved
+ names are not used by derivative works. The fonts and derivatives,
+ however, cannot be released under any other type of license. The
+ requirement for fonts to remain under this license does not apply to
+ any document created using the fonts or their derivatives.
+ .
+ DEFINITIONS
+ .
+ "Font Software" refers to the set of files released by the Copyright
+ Holder(s) under this license and clearly marked as such. This may
+ include source files, build scripts and documentation.
+ .
+ "Reserved Font Name" refers to any names specified as such after the
+ copyright statement(s).
+ .
+ "Original Version" refers to the collection of Font Software components
+ as distributed by the Copyright Holder(s).
+ .
+ "Modified Version" refers to any derivative made by adding to,deleting,
+ or substituting -- in part or in whole -- any of the components of the
+ Original Version, by changing formats or by porting the Font Software
+ to a new environment.
+ .
+ "Author" refers to any designer, engineer, programmer, technical writer
+ or other person who contributed to the Font Software.
+ .
+ PERMISSION & CONDITIONS
+ .
+ Permission is hereby granted, free of charge, to any person obtaining a
+ copy of the Font Software, to use, study, copy, merge, embed, modify,
+ redistribute, and sell modified and unmodified copies of the Font
+ Software, subject to the following conditions:
+ .
+ 1) Neither the Font Software nor any of its individual components, in
+ Original or Modified Versions, may be sold by itself.
+ .
+ 2) Original or Modified Versions of the Font Software may be bundled,
+ redistributed and/or sold with any software, provided that each copy
+ contains the above copyright notice and this license. These can be
+ included either as stand-alone text files, human-readable headers or in
+ the appropriate machine-readable metadata fields within text or binary
+ files as long as those fields can be easily viewed by the user.
+ .
+ 3) No Modified Version of the Font Software may use the Reserved Font
+ Name(s) unless explicit written permission is granted by the
+ corresponding Copyright Holder. This restriction only applies to the
+ primary font name as presented to the users.
+ .
+ 4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+ Software shall not be used to promote, endorse or advertise any
+ Modified Version, except to acknowledge the contribution(s) of the
+ Copyright Holder(s) and the Author(s) or with their explicit written
+ permission.
+ .
+ 5) The Font Software, modified or unmodified, in part or in whole, must
+ be distributed entirely under this license, and must not be distributed
+ under any other license. The requirement for fonts to remain under this
+ license does not apply to any document created using the Font Software.
+ .
+ TERMINATION
+ .
+ This license becomes null and void if any of the above conditions are
+ not met.
+ .
+ DISCLAIMER
+ .
+ THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+ OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+ COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+ DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+ OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/gcc-armv7-fix.patch
+++ b/gcc-armv7-fix.patch
@@ -1,0 +1,18 @@
+diff --unified --recursive --text package.orig/libraries/libnbtplusplus/include/tag_primitive.h package.new/libraries/libnbtplusplus/include/tag_primitive.h
+--- package.orig/libraries/libnbtplusplus/include/tag_primitive.h	2023-07-29 07:27:41.045212463 +0000
++++ package.new/libraries/libnbtplusplus/include/tag_primitive.h	2023-07-29 07:28:19.127613449 +0000
+@@ -77,14 +77,6 @@
+ typedef tag_primitive<float> tag_float;
+ typedef tag_primitive<double> tag_double;
+ 
+-//Explicit instantiations
+-template class NBT_EXPORT tag_primitive<int8_t>;
+-template class NBT_EXPORT tag_primitive<int16_t>;
+-template class NBT_EXPORT tag_primitive<int32_t>;
+-template class NBT_EXPORT tag_primitive<int64_t>;
+-template class NBT_EXPORT tag_primitive<float>;
+-template class NBT_EXPORT tag_primitive<double>;
+-
+ template<class T>
+ void tag_primitive<T>::read_payload(io::stream_reader& reader)
+ {

--- a/postinst.sh
+++ b/postinst.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+cat << EOF
+*==================== PrismLauncher for Debian and Ubuntu ====================*
+ Welcome to PrismLauncher! You will need to install the Java version
+ appropriate for the Minecraft versions you wish to play:
+
+ - Minecraft classic to Minecraft 1.16:
+   apt install java-runtime=8
+ - Minecraft 1.17 to 1.20.4:
+   apt install java-runtime=17
+ - Minecraft 1.20.5 and above:
+   apt install java-runtime=21
+
+ Depending on the support cycles for your distribution, you may
+ need to install a distribution of Java from the Adoptium OpenJDK
+ archives. See https://adoptium.net/installation/linux/ for more details.
+
+ The following optional peer dependencies are available for integration:
+
+ - CMU Flite - Speech synthesis engine that Minecraft uses for the narrator
+   apt install flite
+ - GameMode - Optimise Linux system performance on demand
+   apt install gamemode
+ - MangoHUD - Overlay for monitoring FPS, temperatures, CPU/GPU load and more
+   apt install mangohud
+
+ Note that alternative distributions of PrismLauncher are also available for
+ Debian and Ubuntu via the following package managers:
+
+ - Flatpak: https://flathub.org/apps/org.prismlauncher.PrismLauncher
+    Provides sandboxing and ships Java versions and Qt versions automatically.
+    Works on all recent Debian and Ubuntu versions.
+ - Nix: https://github.com/PrismLauncher/PrismLauncher/blob/develop/flake.nix
+    Works on all recent Debian and Ubuntu versions.
+ - AppImage and Portable: https://prismlauncher.org/download/linux/
+    Not guaranteed to work on all recent Debian and Ubuntu versions.
+ - Pi-Apps: https://pi-apps.io/wiki/getting-started/apps-list/
+    Optimized for older Raspberry Pis running Raspberry Pi OS
+    Not guaranteed to work on all recent Debian and Ubuntu versions.
+
+ This package is intended for use with legacy KDE 5.x distributions such as
+ Debian 12 or Ubuntu 24.04. If this package is not properly adapting to your
+ KDE theme, consider using the \`prismlauncher\` package instead, or use
+ the Flatpak.
+
+ Need help?
+ <3 PrismLauncher Discord: https://discord.gg/ArX2nafFz2
+ <3 PrismLauncher Matrix: https://matrix.to/\#/\#prismlauncher:matrix.org
+ <3 PrismLauncher subreddit: https://www.reddit.com/r/PrismLauncher/
+
+ Bug reports: https://github.com/PrismLauncher/PrismLauncher/issues
+ Packaging bug reports: https://github.com/makedeb/prebuilt-mpr/issues
+*=============================================================================*
+EOF


### PR DESCRIPTION
The following distros have updates available:
- `ubuntu-focal:amd64`
- `ubuntu-focal:arm64`
- `ubuntu-jammy:amd64`
- `ubuntu-jammy:arm64`
- `ubuntu-lunar:amd64`
- `ubuntu-lunar:arm64`
- `ubuntu-mantic:amd64`
- `ubuntu-mantic:arm64`
- `ubuntu-noble:amd64`
- `ubuntu-noble:arm64`
- `debian-bullseye:amd64`
- `debian-bullseye:arm64`
- `debian-bookworm:amd64`
- `debian-bookworm:arm64`

Depending on previously failed builds or newly added distros, there may not be any file changes in this PR. If, however, this information doesn't appear to be correct, please reach out to a Prebuilt-MPR team member.