### PR TITLE
Package Update: `prismlauncher`

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,28 +1,30 @@
-# Maintainer: Sefa Eyeoglu <conctact@scrumplex.net>
+# Maintainer: lordpipe <lordpipe@protonmail.com>
+# Contributor: Sefa Eyeoglu <conctact@scrumplex.net>
 # Contributor: dada513 <dada513@protonmail.com>
-# Contributor: lordpipe <lordpipe@protonmail.com>
 
 pkgname=prismlauncher
-pkgver=8.3
+pkgver=8.4
 pkgrel=1
 pkgdesc='Minecraft launcher with ability to manage multiple instances.'
 arch=('i386' 'amd64' 'arm64' 'armhf' 'riscv64')
 url='https://prismlauncher.org'
 license=('GPL-3')
-depends=('libqt5svg5' 'qt5-image-formats-plugins' 'libqt5xml5' 'libqt5core5a' 'libqt5network5' 'libqt5gui5')
-makedepends=('scdoc' 'extra-cmake-modules' 'cmake' 'git' 'openjdk-17-jdk' 'zlib1g-dev' 'libgl1-mesa-dev' 'qtbase5-dev' 'qtchooser' 'qt5-qmake' 'qtbase5-dev-tools' 'gcc' 'g++')
+depends=('libqt6svg6' 'qt6-image-formats-plugins' 'libqt6xml6' 'libqt6core6' 'libqt6network6' 'libqt6core5compat6')
+makedepends=('scdoc' 'extra-cmake-modules' 'cmake' 'git' 'openjdk-17-jdk' 'zlib1g-dev' 'libgl1-mesa-dev' 'qt6-base-dev' 'qtchooser' 'libqt6core5compat6-dev' 'gcc' 'g++')
 optdepends=('java-runtime=21: support for Minecraft versions >= 1.20.5'
             's!java-runtime=17: support for Minecraft versions >= 1.17 and <= 1.20.4'
             's!java-runtime=8: support for Minecraft versions <= 1.16'
             's!gamemode: support for GameMode'
+            's!mangohud: HUD overlay for FPS and temperatures'
             's!flite: narrator support'
             's!x11-xserver-utils: xrandr is needed to support Minecraft versions <= 1.12')
 source=("https://github.com/PrismLauncher/PrismLauncher/releases/download/$pkgver/PrismLauncher-$pkgver.tar.gz"
         'gcc-armv7-fix.patch'
         'copyright')
-sha256sums=('4d587122f673ee4daea5aa098bd3da0f51989dbb600560146dd8a0375491cea0'
+sha256sums=('a4df9059559df2e410ddf933e05fe4bffaa01631c6eeb55e63af4a2d0d719726'
             '42394447d4b52c9329ff45f3c700c0eb2090a5803c5de010587d64294c37420f'
             '55f14ca1c20ba05785b248b3454ce2671149112d6b7c1a4e4fd24f4dde8f4c71')
+postinst=postinst.sh
 
 # allow for ARM support
 #TODO: makedeb's hard-coding for x86-64 has been fixed in a future makedeb version
@@ -40,16 +42,16 @@ CXXFLAGS=${CXXFLAGS/-fcf-protection/}
 if [[ ${CFLAGS} != *"-mtune"* && ${CFLAGS} != *"-march"* ]]; then
     case "$CARCH" in
         amd64)
-            CFLAGS+=" -march=x86-64 -mtune=generic -fcf-protection"
-            CXXFLAGS+=" -march=x86-64 -mtune=generic -fcf-protection"
+            CFLAGS+=" -march=x86-64 -fcf-protection"
+            CXXFLAGS+=" -march=x86-64 -fcf-protection"
             ;;
         i386)
-            CFLAGS+=" -march=i686 -mtune=generic"
-            CXXFLAGS+=" -march=i686 -mtune=generic"
+            CFLAGS+=" -march=i686"
+            CXXFLAGS+=" -march=i686"
             ;;
         arm64)
-            CFLAGS+=" -march=armv8-a -mtune=generic"
-            CXXFLAGS+=" -march=armv8-a -mtune=generic"
+            CFLAGS+=" -march=armv8-a"
+            CXXFLAGS+=" -march=armv8-a"
             ;;
         armhf)
             CFLAGS+=" -march=armv7-a+fp"
@@ -75,11 +77,10 @@ prepare() {
 
 build() {
     cd "${srcdir}/PrismLauncher-$pkgver"
-    cmake -DCMAKE_BUILD_TYPE=None \
+    cmake -DCMAKE_BUILD_TYPE=Debug \
           -DCMAKE_INSTALL_PREFIX="/usr" \
           -DLauncher_BUILD_PLATFORM="debian" \
           -DLauncher_APP_BINARY_NAME="${pkgname}" \
-          -DLauncher_QT_VERSION_MAJOR=5 \
           -DENABLE_LTO=ON \
           -Bbuild -S.
     cmake --build build

--- a/postinst.sh
+++ b/postinst.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+cat << EOF
+*==================== PrismLauncher for Debian and Ubuntu ====================*
+ Welcome to PrismLauncher! You will need to install the Java version
+ appropriate for the Minecraft versions you wish to play:
+
+ - Minecraft classic to Minecraft 1.16:
+   # apt install java-runtime=8
+ - Minecraft 1.17 to 1.20.4:
+   # apt install java-runtime=17
+ - Minecraft 1.20.5 and above:
+   # apt install java-runtime=21
+
+ Depending on the support cycles for your distribution, you may
+ need to install a distribution of Java from the Adoptium OpenJDK
+ archives. See https://adoptium.net/installation/linux/ for more details
+
+ The following optional peer dependencies are available for integration:
+
+ - CMU Flite - Speech synthesis engine that Minecraft uses for the narrator
+   # apt install flite
+ - GameMode - Optimise Linux system performance on demand
+   # apt install gamemode
+ - MangoHUD - Overlay for monitoring FPS, temperatures, CPU/GPU load and more
+   # apt install mangohud
+
+ Note that alternative distributions of PrismLauncher are also available for
+ Debian and Ubuntu via the following package managers:
+
+ - Flatpak: https://flathub.org/apps/org.prismlauncher.PrismLauncher
+    Provides sandboxing and ships Java versions and Qt versions automatically.
+    Works on all recent Debian and Ubuntu versions.
+ - Nix: https://github.com/PrismLauncher/PrismLauncher/blob/develop/flake.nix
+    Works on all recent Debian and Ubuntu versions.
+ - AppImage and Portable: https://prismlauncher.org/download/linux/
+    Not guaranteed to work on all recent Debian and Ubuntu versions.
+ - Pi-Apps: https://pi-apps.io/wiki/getting-started/apps-list/
+    Optimized for older Raspberry Pis running Raspberry Pi OS
+    Not guaranteed to work on all recent Debian and Ubuntu versions.
+
+ This package is intended for use with KDE Plasma 6.x distributions such
+ as KDE Neon 6 and future Kubuntu versions. If this package is not properly
+ adapting to your KDE theme, consider using the \`prismlauncher-qt5\`
+ package instead, or use the Flatpak.
+
+ Need help?
+
+ PrismLauncher Discord: https://discord.gg/ArX2nafFz2
+ PrismLauncher Matrix: https://matrix.to/\#/\#prismlauncher:matrix.org
+ PrismLauncher subreddit: https://www.reddit.com/r/PrismLauncher/
+
+ Bug reports: https://github.com/PrismLauncher/PrismLauncher/issues
+ Packaging bug reports: https://github.com/makedeb/prebuilt-mpr/issues
+*=============================================================================*
+EOF


### PR DESCRIPTION
The following distros have updates available:
- `ubuntu-focal:amd64`
- `ubuntu-focal:arm64`
- `ubuntu-jammy:amd64`
- `ubuntu-jammy:arm64`
- `ubuntu-lunar:amd64`
- `ubuntu-lunar:arm64`
- `ubuntu-mantic:amd64`
- `ubuntu-mantic:arm64`
- `ubuntu-noble:amd64`
- `ubuntu-noble:arm64`
- `debian-bullseye:amd64`
- `debian-bullseye:arm64`
- `debian-bookworm:amd64`
- `debian-bookworm:arm64`

Depending on previously failed builds or newly added distros, there may not be any file changes in this PR. If, however, this information doesn't appear to be correct, please reach out to a Prebuilt-MPR team member.