### PR TITLE
Package Update: `prismlauncher-qt5`

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=prismlauncher-qt5
 pkgver=8.4
-pkgrel=1
+pkgrel=2
 pkgdesc='Minecraft launcher with ability to manage multiple instances.'
 arch=('i386' 'amd64' 'arm64' 'armhf' 'riscv64')
 url='https://prismlauncher.org'
@@ -80,7 +80,7 @@ build() {
     cmake -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_INSTALL_PREFIX="/usr" \
           -DLauncher_BUILD_PLATFORM="debian" \
-          -DLauncher_APP_BINARY_NAME="${pkgname}" \
+          -DLauncher_APP_BINARY_NAME="prismlauncher" \
           -DLauncher_QT_VERSION_MAJOR=5 \
           -DENABLE_LTO=ON \
           -Bbuild -S.


### PR DESCRIPTION
The following distros have updates available:
- `ubuntu-focal:amd64`
- `ubuntu-focal:arm64`
- `ubuntu-jammy:amd64`
- `ubuntu-jammy:arm64`
- `ubuntu-lunar:amd64`
- `ubuntu-lunar:arm64`
- `ubuntu-mantic:amd64`
- `ubuntu-mantic:arm64`
- `ubuntu-noble:amd64`
- `ubuntu-noble:arm64`
- `debian-bullseye:amd64`
- `debian-bullseye:arm64`
- `debian-bookworm:amd64`
- `debian-bookworm:arm64`

Depending on previously failed builds or newly added distros, there may not be any file changes in this PR. If, however, this information doesn't appear to be correct, please reach out to a Prebuilt-MPR team member.