### PR TITLE
Package Update: `prismlauncher`

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,12 +4,12 @@
 
 pkgname=prismlauncher
 pkgver=8.4
-pkgrel=1
+pkgrel=2
 pkgdesc='Minecraft launcher with ability to manage multiple instances.'
 arch=('i386' 'amd64' 'arm64' 'armhf' 'riscv64')
 url='https://prismlauncher.org'
 license=('GPL-3')
-depends=('libqt6svg6' 'qt6-image-formats-plugins' 'libqt6xml6' 'libqt6core6' 'libqt6network6' 'libqt6core5compat6')
+depends=('libqt6svg6' 'qt6-image-formats-plugins' 'libqt6xml6' 'libqt6core6' 'libqt6network6' 'libqt6core5compat6' 'libqt6widgets6')
 makedepends=('scdoc' 'extra-cmake-modules' 'cmake' 'git' 'openjdk-17-jdk' 'zlib1g-dev' 'libgl1-mesa-dev' 'qt6-base-dev' 'qtchooser' 'libqt6core5compat6-dev' 'gcc' 'g++')
 optdepends=('java-runtime=21: support for Minecraft versions >= 1.20.5'
             's!java-runtime=17: support for Minecraft versions >= 1.17 and <= 1.20.4'

--- a/postinst.sh
+++ b/postinst.sh
@@ -46,7 +46,7 @@ cat << EOF
  Need help?
 
  PrismLauncher Discord: https://discord.gg/ArX2nafFz2
- PrismLauncher Matrix: https://matrix.to/\#/\#prismlauncher:matrix.org
+ PrismLauncher Matrix: https://matrix.to/#/#prismlauncher:matrix.org
  PrismLauncher subreddit: https://www.reddit.com/r/PrismLauncher/
 
  Bug reports: https://github.com/PrismLauncher/PrismLauncher/issues


### PR DESCRIPTION
The following distros have updates available:
- `ubuntu-jammy:amd64`
- `ubuntu-jammy:arm64`
- `ubuntu-lunar:amd64`
- `ubuntu-lunar:arm64`
- `ubuntu-mantic:amd64`
- `ubuntu-mantic:arm64`
- `ubuntu-noble:amd64`
- `ubuntu-noble:arm64`
- `debian-bookworm:amd64`
- `debian-bookworm:arm64`

Depending on previously failed builds or newly added distros, there may not be any file changes in this PR. If, however, this information doesn't appear to be correct, please reach out to a Prebuilt-MPR team member.