### PR TITLE
Package Update: `fjordlauncher`

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,8 +1,11 @@
 # Maintainer: Evan Goode <mail@evangoo.de>
+# Contributor: lordpipe <lordpipe@protonmail.com>
+# Contributor: Sefa Eyeoglu <conctact@scrumplex.net>
+# Contributor: dada513 <dada513@protonmail.com>
 
 pkgname=fjordlauncher
 pkgver=8.4.1
-pkgrel=1
+pkgrel=2
 pkgdesc='Prism Launcher fork with support for alternative auth servers'
 arch=('i386' 'amd64' 'arm64' 'armhf' 'riscv64')
 url='https://github.com/unmojang/FjordLauncher'


### PR DESCRIPTION
The following distros have updates available:
- `ubuntu-jammy:amd64`
- `ubuntu-jammy:arm64`
- `ubuntu-lunar:amd64`
- `ubuntu-lunar:arm64`
- `ubuntu-mantic:amd64`
- `ubuntu-mantic:arm64`
- `ubuntu-noble:amd64`
- `ubuntu-noble:arm64`
- `debian-bookworm:amd64`
- `debian-bookworm:arm64`

Depending on previously failed builds or newly added distros, there may not be any file changes in this PR. If, however, this information doesn't appear to be correct, please reach out to a Prebuilt-MPR team member.