### PR TITLE
Package Update: `rustc`

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -13,8 +13,8 @@ pkgname=(
     'rust-src'
     'rustfmt'
 )
-pkgver=1.79.0
-pkgrel=2
+pkgver=1.80.0
+pkgrel=1
 pkgdesc='The Rust programming language toolchain'
 arch=('any')
 makedepends=(


### PR DESCRIPTION
The following distros have updates available:
- `ubuntu-focal:amd64`
- `ubuntu-jammy:amd64`
- `ubuntu-lunar:amd64`
- `ubuntu-mantic:amd64`
- `ubuntu-noble:amd64`
- `debian-bullseye:amd64`
- `debian-bookworm:amd64`

Depending on previously failed builds or newly added distros, there may not be any file changes in this PR. If, however, this information doesn't appear to be correct, please reach out to a Prebuilt-MPR team member.