### PR TITLE
Package Update: `neovim`

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Hunter Wittenborn <hunter@hunterwittenborn.com>
 pkgname=neovim
-pkgver=0.10.0
+pkgver=0.10.1
 pkgrel=1
 pkgdesc='Vim-fork focused on extensibility and usability'
 arch=('any')


### PR DESCRIPTION
The following distros have updates available:
- `ubuntu-focal:amd64`
- `ubuntu-focal:arm64`
- `ubuntu-jammy:amd64`
- `ubuntu-jammy:arm64`
- `ubuntu-lunar:amd64`
- `ubuntu-lunar:arm64`
- `ubuntu-mantic:amd64`
- `ubuntu-mantic:arm64`
- `ubuntu-noble:amd64`
- `ubuntu-noble:arm64`
- `debian-bullseye:amd64`
- `debian-bullseye:arm64`
- `debian-bookworm:amd64`
- `debian-bookworm:arm64`

Depending on previously failed builds or newly added distros, there may not be any file changes in this PR. If, however, this information doesn't appear to be correct, please reach out to a Prebuilt-MPR team member.