### PR TITLE
Package Update: `element-desktop-bin`

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Hunter Wittenborn <hunter@hunterwittenborn.com>
 pkgname=element-desktop-bin
-pkgver=1.11.72
+pkgver=1.11.73
 pkgrel=1
 pkgdesc="A feature-rich client for Matrix.org"
 arch=('amd64')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Hunter Wittenborn <hunter@hunterwittenborn.com>
 pkgname=element-desktop-bin
-pkgver=1.11.73
+pkgver=1.11.74
 pkgrel=1
 pkgdesc="A feature-rich client for Matrix.org"
 arch=('amd64')


### PR DESCRIPTION
The following distros have updates available:
- `ubuntu-noble:amd64`

Depending on previously failed builds or newly added distros, there may not be any file changes in this PR. If, however, this information doesn't appear to be correct, please reach out to a Prebuilt-MPR team member.