### PR TITLE
Package Update: `discord`

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,7 @@
 # Contributor: Hunter Wittenborn <hunter@hunterwittenborn.com>
 
 pkgname='discord'
-pkgver='0.0.66'
+pkgver='0.0.69'
 pkgrel='1'
 pkgdesc="Chat for Communities and Friends"
 arch=('amd64')
@@ -14,7 +14,7 @@ optdepends=('libappindicator1: Allow the app do display a menu in the system tra
 url="https://discord.com"
 license=('custom')
 source=("${pkgname}::https://dl.discordapp.net/apps/linux/${pkgver}/discord-${pkgver}.deb")
-b2sums=('64548e330cdefdaec0b50dc5acedad9a4ebabdb5d627ed8222f6d7d8c056581d0ebe1a405cd201423dd1bad2ab684fc9c17bd3788beb339fa6de35e9598bbe94')
+b2sums=('d78226b557b4e0beffdcb2b3943320cfde11bbb6a9b195c21231b049f0c476f777ab3a4e36666ecbb81dce0ac54300af0cb1b67f8268ff86fd4eb370eabbe139')
 
 package() {
     tar -xf 'control.tar.gz'


### PR DESCRIPTION
The following distros have updates available:
- `ubuntu-focal:amd64`
- `ubuntu-jammy:amd64`
- `ubuntu-lunar:amd64`
- `ubuntu-mantic:amd64`
- `ubuntu-noble:amd64`
- `debian-bullseye:amd64`
- `debian-bookworm:amd64`

Depending on previously failed builds or newly added distros, there may not be any file changes in this PR. If, however, this information doesn't appear to be correct, please reach out to a Prebuilt-MPR team member.