### PR TITLE
Package Update: `prismlauncher-qt5`

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,25 +3,44 @@
 # Contributor: dada513 <dada513@protonmail.com>
 
 pkgname=prismlauncher-qt5
-pkgver=8.4
-pkgrel=2
+pkgver=9.0
+pkgrel=1
 pkgdesc='Minecraft launcher with ability to manage multiple instances.'
 arch=('i386' 'amd64' 'arm64' 'armhf' 'riscv64')
 url='https://prismlauncher.org'
 license=('GPL-3')
-depends=('libqt5svg5' 'qt5-image-formats-plugins' 'libqt5xml5' 'libqt5core5a' 'libqt5network5' 'libqt5gui5')
-makedepends=('scdoc' 'extra-cmake-modules' 'cmake' 'git' 'openjdk-17-jdk' 'zlib1g-dev' 'libgl1-mesa-dev' 'qtbase5-dev' 'qtchooser' 'qt5-qmake' 'qtbase5-dev-tools' 'gcc' 'g++')
-optdepends=('java-runtime=21: support for Minecraft versions >= 1.20.5'
-            's!java-runtime=17: support for Minecraft versions >= 1.17 and <= 1.20.4'
-            's!java-runtime=8: support for Minecraft versions <= 1.16'
+depends=('libqt5core5a'
+         'libqt5gui5'
+         'libqt5network5'
+         'libqt5networkauth5'
+         'libqt5svg5'
+         'libqt5xml5'
+         'qt5-image-formats-plugins')
+makedepends=('cmake'
+             'extra-cmake-modules'
+             'g++'
+             'gcc'
+             'git'
+             'libgl1-mesa-dev'
+             'libqt5networkauth5-dev'
+             'openjdk-17-jdk'
+             'qt5-qmake'
+             'qtbase5-dev'
+             'qtbase5-dev-tools'
+             'qtchooser'
+             'scdoc'
+             'zlib1g-dev')
+optdepends=('flite: narrator support'
+            'java-runtime=17: support for Minecraft versions >= 1.17 and <= 1.20.4'
+            'java-runtime=21: support for Minecraft versions >= 1.20.5'
+            'java-runtime=8: support for Minecraft versions <= 1.16'
+            'x11-xserver-utils: xrandr is needed to support Minecraft versions <= 1.12'
             's!gamemode: support for GameMode'
-            's!mangohud: HUD overlay for FPS and temperatures'
-            's!flite: narrator support'
-            's!x11-xserver-utils: xrandr is needed to support Minecraft versions <= 1.12')
+            's!mangohud: HUD overlay for FPS and temperatures')
 source=("https://github.com/PrismLauncher/PrismLauncher/releases/download/$pkgver/PrismLauncher-$pkgver.tar.gz"
         'gcc-armv7-fix.patch'
         'copyright')
-sha256sums=('a4df9059559df2e410ddf933e05fe4bffaa01631c6eeb55e63af4a2d0d719726'
+sha256sums=('8c3dae2469c70d460cd8e2747dc4e61c2e31c15f0754d9e41e23563ac544e2be'
             '42394447d4b52c9329ff45f3c700c0eb2090a5803c5de010587d64294c37420f'
             '55f14ca1c20ba05785b248b3454ce2671149112d6b7c1a4e4fd24f4dde8f4c71')
 postinst=postinst.sh
@@ -81,6 +100,7 @@ build() {
           -DCMAKE_INSTALL_PREFIX="/usr" \
           -DLauncher_BUILD_PLATFORM="debian" \
           -DLauncher_APP_BINARY_NAME="prismlauncher" \
+          -DLauncher_ENABLE_JAVA_DOWNLOADER=ON \
           -DLauncher_QT_VERSION_MAJOR=5 \
           -DENABLE_LTO=ON \
           -Bbuild -S.

--- a/postinst.sh
+++ b/postinst.sh
@@ -1,24 +1,10 @@
 #!/bin/bash
 cat << EOF
 *==================== PrismLauncher for Debian and Ubuntu ====================*
- Welcome to PrismLauncher! You will need to install the Java version
- appropriate for the Minecraft versions you wish to play:
-
- - Minecraft classic to Minecraft 1.16:
-   apt install java-runtime=8
- - Minecraft 1.17 to 1.20.4:
-   apt install java-runtime=17
- - Minecraft 1.20.5 and above:
-   apt install java-runtime=21
-
- Depending on the support cycles for your distribution, you may
- need to install a distribution of Java from the Adoptium OpenJDK
- archives. See https://adoptium.net/installation/linux/ for more details.
+ Welcome to PrismLauncher!
 
  The following optional peer dependencies are available for integration:
 
- - CMU Flite - Speech synthesis engine that Minecraft uses for the narrator
-   apt install flite
  - GameMode - Optimise Linux system performance on demand
    apt install gamemode
  - MangoHUD - Overlay for monitoring FPS, temperatures, CPU/GPU load and more
@@ -28,7 +14,7 @@ cat << EOF
  Debian and Ubuntu via the following package managers:
 
  - Flatpak: https://flathub.org/apps/org.prismlauncher.PrismLauncher
-    Provides sandboxing and ships Java versions and Qt versions automatically.
+    Provides sandboxing, but requires slightly more disk space.
     Works on all recent Debian and Ubuntu versions.
  - Nix: https://github.com/PrismLauncher/PrismLauncher/blob/develop/flake.nix
     Works on all recent Debian and Ubuntu versions.


### PR DESCRIPTION
The following distros have updates available:
- `ubuntu-focal:amd64`
- `ubuntu-focal:arm64`
- `ubuntu-jammy:amd64`
- `ubuntu-jammy:arm64`
- `ubuntu-lunar:amd64`
- `ubuntu-lunar:arm64`
- `ubuntu-mantic:amd64`
- `ubuntu-mantic:arm64`
- `ubuntu-noble:amd64`
- `ubuntu-noble:arm64`
- `ubuntu-oracular:amd64`
- `ubuntu-oracular:arm64`
- `debian-bullseye:amd64`
- `debian-bullseye:arm64`
- `debian-bookworm:amd64`
- `debian-bookworm:arm64`

Depending on previously failed builds or newly added distros, there may not be any file changes in this PR. If, however, this information doesn't appear to be correct, please reach out to a Prebuilt-MPR team member.