### PR TITLE
Package Update: `woeusb-ng`

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,12 +1,12 @@
 # Maintainer: Hunter Wittenborn <hunter@hunterwittenborn.com>
 pkgname=woeusb-ng
 pkgver=0.2.10
-pkgrel=3
+pkgrel=4
 pkgdesc='Simple tool that enables you to create your own USB stick Windows installer'
 arch=('any')
 depends=(
     'dosfstools'
-    'grub-pc-bin'
+    'grub-pc'
     'grub2-common'
     'ntfs-3g'
     'p7zip-full'


### PR DESCRIPTION
The following distros have updates available:
- `ubuntu-focal:arm64`
- `ubuntu-jammy:arm64`
- `ubuntu-lunar:arm64`
- `ubuntu-mantic:arm64`
- `ubuntu-noble:arm64`
- `ubuntu-oracular:amd64`
- `ubuntu-oracular:arm64`
- `debian-bullseye:arm64`
- `debian-bookworm:arm64`

Depending on previously failed builds or newly added distros, there may not be any file changes in this PR. If, however, this information doesn't appear to be correct, please reach out to a Prebuilt-MPR team member.