### PR TITLE
Package Update: `fjordlauncher`

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,30 +1,58 @@
 # Maintainer: Evan Goode <mail@evangoo.de>
 # Contributor: lordpipe <lordpipe@protonmail.com>
+# Contributor: txtsd <mpr.makedeb@ihavea.quest>
 # Contributor: Sefa Eyeoglu <conctact@scrumplex.net>
 # Contributor: dada513 <dada513@protonmail.com>
 
 pkgname=fjordlauncher
-pkgver=8.4.2
+pkgver=9.1.0
 pkgrel=1
 pkgdesc='Prism Launcher fork with support for alternative auth servers'
 arch=('i386' 'amd64' 'arm64' 'armhf' 'riscv64')
 url='https://github.com/unmojang/FjordLauncher'
 license=('GPL-3')
-depends=('libqt6svg6' 'qt6-image-formats-plugins' 'libqt6xml6' 'libqt6core6' 'libqt6network6' 'libqt6core5compat6')
-makedepends=('scdoc' 'extra-cmake-modules' 'cmake' 'git' 'openjdk-17-jdk' 'zlib1g-dev' 'libgl1-mesa-dev' 'qt6-base-dev' 'qtchooser' 'libqt6core5compat6-dev' 'gcc' 'g++')
-optdepends=('java-runtime=21: support for Minecraft versions >= 1.20.5'
-            's!java-runtime=17: support for Minecraft versions >= 1.17 and <= 1.20.4'
-            's!java-runtime=8: support for Minecraft versions <= 1.16'
-            's!gamemode: support for GameMode'
-            's!mangohud: HUD overlay for FPS and temperatures'
-            's!flite: narrator support'
-            's!x11-xserver-utils: xrandr is needed to support Minecraft versions <= 1.12')
-source=("https://github.com/unmojang/FjordLauncher/releases/download/$pkgver/FjordLauncher-$pkgver.tar.gz"
-        'gcc-armv7-fix.patch'
-        'copyright')
-sha256sums=('6a4290ed37615f37449659433338cb205813b34a9da7e30543ab3497dfd7282b'
+depends=(
+  'libqt6core5compat6'
+  'libqt6core6'
+  'libqt6network6'
+  'libqt6networkauth6'
+  'libqt6svg6'
+  'libqt6widgets6'
+  'libqt6xml6'
+  'qt6-image-formats-plugins'
+)
+makedepends=(
+  'cmake'
+  'extra-cmake-modules'
+  'g++'
+  'gcc'
+  'git'
+  'libgl1-mesa-dev'
+  'libqt6core5compat6-dev'
+  'openjdk-17-jdk'
+  'qt6-base-dev'
+  'qt6-networkauth-dev'
+  'qtchooser'
+  'scdoc'
+  'zlib1g-dev'
+)
+optdepends=(
+  'flite: narrator support'
+  'java-runtime=17: support for Minecraft versions >= 1.17 and <= 1.20.4'
+  'java-runtime=21: support for Minecraft versions >= 1.20.5'
+  'java-runtime=8: support for Minecraft versions <= 1.16'
+  'x11-xserver-utils: xrandr is needed to support Minecraft versions <= 1.12'
+  's!gamemode: support for GameMode'
+  's!mangohud: HUD overlay for FPS and temperatures'
+)
+source=(
+  "https://github.com/unmojang/FjordLauncher/releases/download/${pkgver}/FjordLauncher-${pkgver}.tar.gz"
+  'gcc-armv7-fix.patch'
+  'copyright'
+)
+sha256sums=('bd95bfc4e6e2b7fa3651b597814f242359fda292d2f590ad7d056b1c2fc144ac'
             '42394447d4b52c9329ff45f3c700c0eb2090a5803c5de010587d64294c37420f'
-            '276999f42582d6ac34410b4b008cbbcf03b2a93b587d3393038c37c991085c2b')
+            'fefd606e959a9c6c8ba947a7d351b85f57f1d52b962bc3c674522b7a6fb48460')
 postinst=postinst.sh
 
 # allow for ARM support
@@ -41,62 +69,65 @@ CXXFLAGS=${CXXFLAGS/-fcf-protection/}
 
 # if the user hasn't specified a tuning/architecture, specify our own minimal defaults to cover the earliest CPUs
 if [[ ${CFLAGS} != *"-mtune"* && ${CFLAGS} != *"-march"* ]]; then
-    case "$CARCH" in
-        amd64)
-            CFLAGS+=" -march=x86-64 -fcf-protection"
-            CXXFLAGS+=" -march=x86-64 -fcf-protection"
-            ;;
-        i386)
-            CFLAGS+=" -march=i686"
-            CXXFLAGS+=" -march=i686"
-            ;;
-        arm64)
-            CFLAGS+=" -march=armv8-a"
-            CXXFLAGS+=" -march=armv8-a"
-            ;;
-        armhf)
-            CFLAGS+=" -march=armv7-a+fp"
-            CXXFLAGS+=" -march=armv7-a+fp"
-            ;;
-        riscv64)
-            CFLAGS+=" -march=rv64imafdc"
-            CXXFLAGS+=" -march=rv64imafdc"
-            ;;
-    esac
+  case "${CARCH}" in
+    amd64)
+      CFLAGS+=" -march=x86-64 -fcf-protection"
+      CXXFLAGS+=" -march=x86-64 -fcf-protection"
+      ;;
+    i386)
+      CFLAGS+=" -march=i686"
+      CXXFLAGS+=" -march=i686"
+      ;;
+    arm64)
+      CFLAGS+=" -march=armv8-a"
+      CXXFLAGS+=" -march=armv8-a"
+      ;;
+    armhf)
+      CFLAGS+=" -march=armv7-a+fp"
+      CXXFLAGS+=" -march=armv7-a+fp"
+      ;;
+    riscv64)
+      CFLAGS+=" -march=rv64imafdc"
+      CXXFLAGS+=" -march=rv64imafdc"
+      ;;
+  esac
 fi
 
 prepare() {
-    # workaround https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64860
-    # more info: https://github.com/PrismLauncher/PrismLauncher/issues/128
-    if [[ "$(uname -m)" = armv7* ]]; then
-        echo "GCC / ARMv7 fix is needed for this architecture, applying gcc-armv7-fix.patch"
-        patch --directory="FjordLauncher-$pkgver" --forward --strip=1 --input="${srcdir}/gcc-armv7-fix.patch"
-    else
-        echo "GCC / ARMv7 fix is not needed for this architecture, skipping gcc-armv7-fix.patch"
-    fi
+  # workaround https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64860
+  # more info: https://github.com/PrismLauncher/PrismLauncher/issues/128
+  if [[ "$(uname -m)" = armv7* ]]; then
+    echo "GCC / ARMv7 fix is needed for this architecture, applying gcc-armv7-fix.patch"
+    patch --directory="FjordLauncher-${pkgver}" --forward --strip=1 --input="${srcdir}/gcc-armv7-fix.patch"
+  else
+    echo "GCC / ARMv7 fix is not needed for this architecture, skipping gcc-armv7-fix.patch"
+  fi
 }
 
 build() {
-    cd "${srcdir}/FjordLauncher-$pkgver"
-    cmake -DCMAKE_BUILD_TYPE=Debug \
-          -DCMAKE_INSTALL_PREFIX="/usr" \
-          -DLauncher_BUILD_PLATFORM="debian" \
-          -DLauncher_APP_BINARY_NAME="${pkgname}" \
-          -DENABLE_LTO=ON \
-          -Bbuild -S.
-    cmake --build build
+  cd "${srcdir}/FjordLauncher-${pkgver}"
+  cmake -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="/usr" \
+    -DLauncher_BUILD_PLATFORM="debian" \
+    -DLauncher_APP_BINARY_NAME="${pkgname}" \
+    -DLauncher_ENABLE_JAVA_DOWNLOADER=ON \
+    -DENABLE_LTO=ON \
+    -Bbuild -S.
+  cmake --build build
 }
 
 check() {
-    cd "${srcdir}/FjordLauncher-$pkgver/build"
-    ctest . -E Task  # Skip unreliable Task test
+  cd "${srcdir}/FjordLauncher-${pkgver}/build"
+  ctest . -E Task  # Skip unreliable Task test
 }
 
 package() {
-    cd "${srcdir}/FjordLauncher-$pkgver/build"
-    DESTDIR="$pkgdir" cmake --install .
-    mkdir -p "${pkgdir}/usr/share/doc/$pkgname"
-    mv "${pkgdir}/usr/share/mime/packages/modrinth-mrpack-mime.xml" \
-       "${pkgdir}/usr/share/mime/packages/fjordlauncher-modrinth-mrpack-mime.xml"
-    cp -v "${srcdir}/copyright" "${pkgdir}/usr/share/doc/$pkgname/copyright"
+  cd "${srcdir}/FjordLauncher-${pkgver}/build"
+  DESTDIR="${pkgdir}" cmake --install .
+  mkdir -p "${pkgdir}/usr/share/doc/${pkgname}"
+  mv "${pkgdir}/usr/share/mime/packages/modrinth-mrpack-mime.xml" \
+     "${pkgdir}/usr/share/mime/packages/fjordlauncher-modrinth-mrpack-mime.xml"
+  cp -v "${srcdir}/copyright" "${pkgdir}/usr/share/doc/${pkgname}/copyright"
 }
+
+# vim: set sw=2 expandtab:

--- a/copyright
+++ b/copyright
@@ -67,7 +67,8 @@ License: Expat
 
 Files:
  launcher/resources/*
-Copyright: 2022-2023, PollyMC Contributors
+Copyright: 2024-2024, Fjord Launcher Contributors
+           2022-2023, PollyMC Contributors
            2022-2023, Prism Launcher Contributors
            2021-2022, PolyMC Contributors
            2014-2023, KDE Contributors


### PR DESCRIPTION
The following distros have updates available:
- `ubuntu-jammy:amd64`
- `ubuntu-jammy:arm64`
- `ubuntu-lunar:amd64`
- `ubuntu-lunar:arm64`
- `ubuntu-mantic:amd64`
- `ubuntu-mantic:arm64`
- `ubuntu-noble:amd64`
- `ubuntu-noble:arm64`
- `ubuntu-oracular:amd64`
- `ubuntu-oracular:arm64`
- `debian-bookworm:amd64`
- `debian-bookworm:arm64`

Depending on previously failed builds or newly added distros, there may not be any file changes in this PR. If, however, this information doesn't appear to be correct, please reach out to a Prebuilt-MPR team member.