### PR TITLE
Package Update: `discord`

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,7 @@
 # Contributor: Hunter Wittenborn <hunter@hunterwittenborn.com>
 
 pkgname='discord'
-pkgver='0.0.73'
+pkgver='0.0.75'
 pkgrel='1'
 pkgdesc="Chat for Communities and Friends"
 arch=('amd64')
@@ -14,7 +14,7 @@ optdepends=('libappindicator1: Allow the app do display a menu in the system tra
 url="https://discord.com"
 license=('custom')
 source=("${pkgname}::https://dl.discordapp.net/apps/linux/${pkgver}/discord-${pkgver}.deb")
-b2sums=('bd390edf1a2d4f299d59463da97c748b9d02de6701d9187336360af8cf9eb94bfe6d4f85992bc60e7d5d9921864c4e4ea403363f9bf28399c9704df065fe4935')
+b2sums=('3b25d25521b42f7c2d38d00888320758d80a08d8def20a11eb64ae84247cc992571efdd84f3146cf3b1a06365aab141e12033baa7149666f043ce29c007183dc')
 
 package() {
     tar -xf 'control.tar.gz'

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,7 @@
 # Contributor: Hunter Wittenborn <hunter@hunterwittenborn.com>
 
 pkgname='discord'
-pkgver='0.0.78'
+pkgver='0.0.82'
 pkgrel='1'
 pkgdesc="Chat for Communities and Friends"
 arch=('amd64')
@@ -14,7 +14,7 @@ optdepends=('libappindicator1: Allow the app do display a menu in the system tra
 url="https://discord.com"
 license=('custom')
 source=("${pkgname}::https://dl.discordapp.net/apps/linux/${pkgver}/discord-${pkgver}.deb")
-b2sums=('97367405354c3c684b07c946117435291c62d5da0762c188526c3b067e437f0e449b303cd0490703cf36833e5050bcf83701f59ad9ebbd3340f216414d16a2f3')
+b2sums=('89772ae14dbc6157e53926aa8271aafb9a7d97234bd425a351c1510072775e5b05feacae2c4f81cebbdb75ccedb471a2298f62c9066d0413e3df04ec347c039b')
 
 package() {
     tar -xf 'control.tar.gz'

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,7 @@
 # Contributor: Hunter Wittenborn <hunter@hunterwittenborn.com>
 
 pkgname='discord'
-pkgver='0.0.75'
+pkgver='0.0.77'
 pkgrel='1'
 pkgdesc="Chat for Communities and Friends"
 arch=('amd64')
@@ -14,7 +14,7 @@ optdepends=('libappindicator1: Allow the app do display a menu in the system tra
 url="https://discord.com"
 license=('custom')
 source=("${pkgname}::https://dl.discordapp.net/apps/linux/${pkgver}/discord-${pkgver}.deb")
-b2sums=('3b25d25521b42f7c2d38d00888320758d80a08d8def20a11eb64ae84247cc992571efdd84f3146cf3b1a06365aab141e12033baa7149666f043ce29c007183dc')
+b2sums=('1dc779cc98d14f681bc1fb42373fc5f01bbf8c61e321e67b86f3677da908967b01fad8693201a05735232f09b5a3391d8fad7130a7a467f68d0bc50fccd5f924')
 
 package() {
     tar -xf 'control.tar.gz'

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,7 @@
 # Contributor: Hunter Wittenborn <hunter@hunterwittenborn.com>
 
 pkgname='discord'
-pkgver='0.0.77'
+pkgver='0.0.78'
 pkgrel='1'
 pkgdesc="Chat for Communities and Friends"
 arch=('amd64')
@@ -14,7 +14,7 @@ optdepends=('libappindicator1: Allow the app do display a menu in the system tra
 url="https://discord.com"
 license=('custom')
 source=("${pkgname}::https://dl.discordapp.net/apps/linux/${pkgver}/discord-${pkgver}.deb")
-b2sums=('1dc779cc98d14f681bc1fb42373fc5f01bbf8c61e321e67b86f3677da908967b01fad8693201a05735232f09b5a3391d8fad7130a7a467f68d0bc50fccd5f924')
+b2sums=('97367405354c3c684b07c946117435291c62d5da0762c188526c3b067e437f0e449b303cd0490703cf36833e5050bcf83701f59ad9ebbd3340f216414d16a2f3')
 
 package() {
     tar -xf 'control.tar.gz'


### PR DESCRIPTION
The following distros have updates available:
- `ubuntu-focal:amd64`
- `ubuntu-jammy:amd64`
- `ubuntu-lunar:amd64`
- `ubuntu-mantic:amd64`
- `ubuntu-noble:amd64`
- `ubuntu-oracular:amd64`
- `debian-bullseye:amd64`
- `debian-bookworm:amd64`

Depending on previously failed builds or newly added distros, there may not be any file changes in this PR. If, however, this information doesn't appear to be correct, please reach out to a Prebuilt-MPR team member.