### PR TITLE
Package Update: `golang-go-bin`

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,7 +3,7 @@
 epoch=2
 repology_pkgname=go
 pkgname=golang-go-bin
-pkgver=1.24.1
+pkgver=1.24.2
 pkgrel=1
 pkgdesc='The Go programming language'
 arch=(amd64 arm64)
@@ -16,8 +16,8 @@ url='https://github.com/golang/go'
 
 source_arm64=("https://go.dev/dl/go${pkgver}.linux-arm64.tar.gz")
 source_amd64=("https://go.dev/dl/go${pkgver}.linux-amd64.tar.gz")
-sha256sums_amd64=('cb2396bae64183cdccf81a9a6df0aea3bce9511fc21469fb89a0c00470088073')
-sha256sums_arm64=('8df5750ffc0281017fb6070fba450f5d22b600a02081dceef47966ffaf36a3af')
+sha256sums_amd64=('68097bd680839cbc9d464a0edce4f7c333975e27a90246890e9f1078c7e702ad')
+sha256sums_arm64=('756274ea4b68fa5535eb9fe2559889287d725a8da63c6aae4d5f23778c229f4b')
 
 extensions=('zipman')
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,7 +3,7 @@
 epoch=2
 repology_pkgname=go
 pkgname=golang-go-bin
-pkgver=1.23.2
+pkgver=1.23.3
 pkgrel=1
 pkgdesc='The Go programming language'
 arch=(amd64 arm64)
@@ -16,8 +16,8 @@ url='https://github.com/golang/go'
 
 source_arm64=("https://go.dev/dl/go${pkgver}.linux-arm64.tar.gz")
 source_amd64=("https://go.dev/dl/go${pkgver}.linux-amd64.tar.gz")
-sha256sums_amd64=('542d3c1705f1c6a1c5a80d5dc62e2e45171af291e755d591c5e6531ef63b454e')
-sha256sums_arm64=('f626cdd92fc21a88b31c1251f419c17782933a42903db87a174ce74eeecc66a9')
+sha256sums_amd64=('a0afb9744c00648bafb1b90b4aba5bdb86f424f02f9275399ce0c20b93a2c3a8')
+sha256sums_arm64=('1f7cbd7f668ea32a107ecd41b6488aaee1f5d77a66efd885b175494439d4e1ce')
 
 extensions=('zipman')
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,7 +3,7 @@
 epoch=2
 repology_pkgname=go
 pkgname=golang-go-bin
-pkgver=1.24.0
+pkgver=1.24.1
 pkgrel=1
 pkgdesc='The Go programming language'
 arch=(amd64 arm64)
@@ -16,8 +16,8 @@ url='https://github.com/golang/go'
 
 source_arm64=("https://go.dev/dl/go${pkgver}.linux-arm64.tar.gz")
 source_amd64=("https://go.dev/dl/go${pkgver}.linux-amd64.tar.gz")
-sha256sums_amd64=('dea9ca38a0b852a74e81c26134671af7c0fbe65d81b0dc1c5bfe22cf7d4c8858')
-sha256sums_arm64=('c3fa6d16ffa261091a5617145553c71d21435ce547e44cc6dfb7470865527cc7')
+sha256sums_amd64=('cb2396bae64183cdccf81a9a6df0aea3bce9511fc21469fb89a0c00470088073')
+sha256sums_arm64=('8df5750ffc0281017fb6070fba450f5d22b600a02081dceef47966ffaf36a3af')
 
 extensions=('zipman')
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,7 +3,7 @@
 epoch=2
 repology_pkgname=go
 pkgname=golang-go-bin
-pkgver=1.23.3
+pkgver=1.23.4
 pkgrel=1
 pkgdesc='The Go programming language'
 arch=(amd64 arm64)
@@ -16,8 +16,8 @@ url='https://github.com/golang/go'
 
 source_arm64=("https://go.dev/dl/go${pkgver}.linux-arm64.tar.gz")
 source_amd64=("https://go.dev/dl/go${pkgver}.linux-amd64.tar.gz")
-sha256sums_amd64=('a0afb9744c00648bafb1b90b4aba5bdb86f424f02f9275399ce0c20b93a2c3a8')
-sha256sums_arm64=('1f7cbd7f668ea32a107ecd41b6488aaee1f5d77a66efd885b175494439d4e1ce')
+sha256sums_amd64=('6924efde5de86fe277676e929dc9917d466efa02fb934197bc2eba35d5680971')
+sha256sums_arm64=('16e5017863a7f6071363782b1b8042eb12c6ca4f4cd71528b2123f0a1275b13e')
 
 extensions=('zipman')
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,7 +3,7 @@
 epoch=2
 repology_pkgname=go
 pkgname=golang-go-bin
-pkgver=1.23.5
+pkgver=1.23.6
 pkgrel=1
 pkgdesc='The Go programming language'
 arch=(amd64 arm64)
@@ -16,8 +16,8 @@ url='https://github.com/golang/go'
 
 source_arm64=("https://go.dev/dl/go${pkgver}.linux-arm64.tar.gz")
 source_amd64=("https://go.dev/dl/go${pkgver}.linux-amd64.tar.gz")
-sha256sums_amd64=('cbcad4a6482107c7c7926df1608106c189417163428200ce357695cc7e01d091')
-sha256sums_arm64=('47c84d332123883653b70da2db7dd57d2a865921ba4724efcdf56b5da7021db0')
+sha256sums_amd64=('9379441ea310de000f33a4dc767bd966e72ab2826270e038e78b2c53c2e7802d')
+sha256sums_arm64=('561c780e8f4a8955d32bf72e46af0b5ee5e0debe1e4633df9a03781878219202')
 
 extensions=('zipman')
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,7 +3,7 @@
 epoch=2
 repology_pkgname=go
 pkgname=golang-go-bin
-pkgver=1.23.4
+pkgver=1.23.5
 pkgrel=1
 pkgdesc='The Go programming language'
 arch=(amd64 arm64)
@@ -16,8 +16,8 @@ url='https://github.com/golang/go'
 
 source_arm64=("https://go.dev/dl/go${pkgver}.linux-arm64.tar.gz")
 source_amd64=("https://go.dev/dl/go${pkgver}.linux-amd64.tar.gz")
-sha256sums_amd64=('6924efde5de86fe277676e929dc9917d466efa02fb934197bc2eba35d5680971')
-sha256sums_arm64=('16e5017863a7f6071363782b1b8042eb12c6ca4f4cd71528b2123f0a1275b13e')
+sha256sums_amd64=('cbcad4a6482107c7c7926df1608106c189417163428200ce357695cc7e01d091')
+sha256sums_arm64=('47c84d332123883653b70da2db7dd57d2a865921ba4724efcdf56b5da7021db0')
 
 extensions=('zipman')
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,7 +3,7 @@
 epoch=2
 repology_pkgname=go
 pkgname=golang-go-bin
-pkgver=1.23.6
+pkgver=1.24.0
 pkgrel=1
 pkgdesc='The Go programming language'
 arch=(amd64 arm64)
@@ -16,8 +16,8 @@ url='https://github.com/golang/go'
 
 source_arm64=("https://go.dev/dl/go${pkgver}.linux-arm64.tar.gz")
 source_amd64=("https://go.dev/dl/go${pkgver}.linux-amd64.tar.gz")
-sha256sums_amd64=('9379441ea310de000f33a4dc767bd966e72ab2826270e038e78b2c53c2e7802d')
-sha256sums_arm64=('561c780e8f4a8955d32bf72e46af0b5ee5e0debe1e4633df9a03781878219202')
+sha256sums_amd64=('dea9ca38a0b852a74e81c26134671af7c0fbe65d81b0dc1c5bfe22cf7d4c8858')
+sha256sums_arm64=('c3fa6d16ffa261091a5617145553c71d21435ce547e44cc6dfb7470865527cc7')
 
 extensions=('zipman')
 


### PR DESCRIPTION
The following distros have updates available:
- `ubuntu-focal:amd64`
- `ubuntu-focal:arm64`
- `ubuntu-jammy:amd64`
- `ubuntu-jammy:arm64`
- `ubuntu-lunar:amd64`
- `ubuntu-lunar:arm64`
- `ubuntu-mantic:amd64`
- `ubuntu-mantic:arm64`
- `ubuntu-noble:amd64`
- `ubuntu-noble:arm64`
- `ubuntu-oracular:amd64`
- `ubuntu-oracular:arm64`
- `debian-bullseye:amd64`
- `debian-bullseye:arm64`
- `debian-bookworm:amd64`
- `debian-bookworm:arm64`

Depending on previously failed builds or newly added distros, there may not be any file changes in this PR. If, however, this information doesn't appear to be correct, please reach out to a Prebuilt-MPR team member.