### PR TITLE
Package Update: `element-desktop-bin`

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,15 +1,21 @@
 # Maintainer: Hunter Wittenborn <hunter@hunterwittenborn.com>
 pkgname=element-desktop-bin
-pkgver=1.11.74
+pkgver=1.11.86
 pkgrel=1
 pkgdesc="A feature-rich client for Matrix.org"
 arch=('amd64')
 url="https://element.io/"
 license=('Apache-2.0')
-depends=('libgtk-3-0' 'libnotify4' 'libnss3' 'libxss1' 'libxtst6' 'xdg-utils' 'libatspi2.0-0' 'libuuid1' 'libsecret-1-0' 'libsqlcipher0')
+depends=('libgtk-3-0' 'libnotify4' 'libnss3' 'libxss1' 'libxtst6' 'xdg-utils' 'libatspi2.0-0' 'libuuid1' 'libsecret-1-0')
 optdepends=('libappindicator3-1')
 conflicts=('riot-desktop<1.7.0' 'riot-web<1.7.0')
 replaces=('riot-desktop<1.7.0' 'riot-web<1.7.0')
+
+if [[ "${MAKEDEB_DISTRO_CODENAME}" == 'oracular' || "${MAKEDEB_DISTRO_CODENAME}" == 'noble' ]]; then
+	depends+=('libsqlcipher1')
+else
+	depends+=('libsqlcipher0')
+fi
 
 source=("https://packages.element.io/debian/pool/main/e/element-desktop/element-desktop_${pkgver}_amd64.deb")
 sha256sums=('SKIP')


### PR DESCRIPTION
The following distros have updates available:
- `ubuntu-noble:amd64`
- `ubuntu-oracular:amd64`

Depending on previously failed builds or newly added distros, there may not be any file changes in this PR. If, however, this information doesn't appear to be correct, please reach out to a Prebuilt-MPR team member.