### PR TITLE
Package Update: `code-bin`

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Hunter Wittenborn <hunter@hunterwittenborn.com>
 pkgname='code-bin'
-pkgver='1.95.3'
+pkgver='1.97.2'
 pkgrel='1'
 pkgdesc="Code editing. Redefined."
 arch=('amd64')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,19 +1,16 @@
-# Maintainer: hiddeninthesand <hiddeninthesand at pm dot me>
-
-# Contributor: Hunter Wittenborn <hunter@hunterwittenborn.com>
-
+# Maintainer: Hunter Wittenborn <hunter@hunterwittenborn.com>
 pkgname='code-bin'
-pkgver='1.74.3'
+pkgver='1.95.3'
 pkgrel='1'
 pkgdesc="Code editing. Redefined."
-arch=('x86_64')
+arch=('amd64')
 depends=('libnss3>=2:3.26' 'gnupg' 'apt' 'libxkbfile1' 'libsecret-1-0' 'libgtk-3-0>=3.10.0' 'libxss1' 'libgbm1')
 provides=('visual-studio-code')
 _base_url='code.visualstudio.com'
 url="https://${_base_url}"
 
 source=("code-${pkgver}.deb::https://update.${_base_url}/${pkgver}/linux-deb-x64/stable")
-b2sums=('ed513f28df016690684565cc8b440588e664ad0da6ff4abf251df20c6bb1f8394bc3cd712c33be2cb25bfc3ccab2ac072037e1ab875c86ee6323c61eba6f946c')
+sha256sums=('SKIP')
 
 package() {
   msg2 "Extracting data.tar.xz..."


### PR DESCRIPTION
The following distros have updates available:
- `ubuntu-focal:amd64`
- `ubuntu-jammy:amd64`
- `ubuntu-lunar:amd64`
- `ubuntu-mantic:amd64`
- `ubuntu-noble:amd64`
- `ubuntu-oracular:amd64`
- `debian-bullseye:amd64`
- `debian-bookworm:amd64`

Depending on previously failed builds or newly added distros, there may not be any file changes in this PR. If, however, this information doesn't appear to be correct, please reach out to a Prebuilt-MPR team member.