### PR TITLE
Package Update: `discord`

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,7 @@
 # Contributor: Hunter Wittenborn <hunter@hunterwittenborn.com>
 
 pkgname='discord'
-pkgver='0.0.85'
+pkgver='0.0.87'
 pkgrel='1'
 pkgdesc="Chat for Communities and Friends"
 arch=('amd64')
@@ -14,7 +14,7 @@ optdepends=('libappindicator1: Allow the app do display a menu in the system tra
 url="https://discord.com"
 license=('custom')
 source=("${pkgname}::https://dl.discordapp.net/apps/linux/${pkgver}/discord-${pkgver}.deb")
-b2sums=('8b2aef7a76e032c37beac4e12ed8e6d9c7db15c4d4d6d6433204fe72ae3ac551f7b2c5dbc10351ad1a95b6747ad4d2164bfbef1c9e70d9e4bff235754cc529d4')
+b2sums=('92fc61abe44f20a5b2a5bd1db594d594617798edf7f4e91fc5d7dd0d5ebc56fe9d841f6609d7e2c32093103255290773d910d9de1829ec1338e6083b48425042')
 
 package() {
     tar -xf 'control.tar.gz'

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,7 @@
 # Contributor: Hunter Wittenborn <hunter@hunterwittenborn.com>
 
 pkgname='discord'
-pkgver='0.0.87'
+pkgver='0.0.88'
 pkgrel='1'
 pkgdesc="Chat for Communities and Friends"
 arch=('amd64')
@@ -14,7 +14,7 @@ optdepends=('libappindicator1: Allow the app do display a menu in the system tra
 url="https://discord.com"
 license=('custom')
 source=("${pkgname}::https://dl.discordapp.net/apps/linux/${pkgver}/discord-${pkgver}.deb")
-b2sums=('92fc61abe44f20a5b2a5bd1db594d594617798edf7f4e91fc5d7dd0d5ebc56fe9d841f6609d7e2c32093103255290773d910d9de1829ec1338e6083b48425042')
+b2sums=('e34dfbfc009d1ce282f60a1c38e8a9f3aafb70f932088d82e2539a8c923ba068a92148aa17cb30a71e70dcc3407c6be085776c8eaf5f12db6e9804abe0887815')
 
 package() {
     tar -xf 'control.tar.gz'

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,7 @@
 # Contributor: Hunter Wittenborn <hunter@hunterwittenborn.com>
 
 pkgname='discord'
-pkgver='0.0.84'
+pkgver='0.0.85'
 pkgrel='1'
 pkgdesc="Chat for Communities and Friends"
 arch=('amd64')
@@ -14,7 +14,7 @@ optdepends=('libappindicator1: Allow the app do display a menu in the system tra
 url="https://discord.com"
 license=('custom')
 source=("${pkgname}::https://dl.discordapp.net/apps/linux/${pkgver}/discord-${pkgver}.deb")
-b2sums=('5afc26c942a65e7843f9d526f84dbd0223c7ef98f3d46fe4a298592c5d8e184a16bf5b62040369e215139a329248df0e1dea3d07090ef404fcc07727fbcb7192')
+b2sums=('8b2aef7a76e032c37beac4e12ed8e6d9c7db15c4d4d6d6433204fe72ae3ac551f7b2c5dbc10351ad1a95b6747ad4d2164bfbef1c9e70d9e4bff235754cc529d4')
 
 package() {
     tar -xf 'control.tar.gz'

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,7 @@
 # Contributor: Hunter Wittenborn <hunter@hunterwittenborn.com>
 
 pkgname='discord'
-pkgver='0.0.82'
+pkgver='0.0.84'
 pkgrel='1'
 pkgdesc="Chat for Communities and Friends"
 arch=('amd64')
@@ -14,7 +14,7 @@ optdepends=('libappindicator1: Allow the app do display a menu in the system tra
 url="https://discord.com"
 license=('custom')
 source=("${pkgname}::https://dl.discordapp.net/apps/linux/${pkgver}/discord-${pkgver}.deb")
-b2sums=('89772ae14dbc6157e53926aa8271aafb9a7d97234bd425a351c1510072775e5b05feacae2c4f81cebbdb75ccedb471a2298f62c9066d0413e3df04ec347c039b')
+b2sums=('5afc26c942a65e7843f9d526f84dbd0223c7ef98f3d46fe4a298592c5d8e184a16bf5b62040369e215139a329248df0e1dea3d07090ef404fcc07727fbcb7192')
 
 package() {
     tar -xf 'control.tar.gz'


### PR DESCRIPTION
The following distros have updates available:
- `ubuntu-lunar:amd64`
- `ubuntu-mantic:amd64`

Depending on previously failed builds or newly added distros, there may not be any file changes in this PR. If, however, this information doesn't appear to be correct, please reach out to a Prebuilt-MPR team member.