### PR TITLE
Package Update: `polymc`

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -8,28 +8,44 @@
 # Contributor: Cheru Berhanu <aur attt cheru doot dev>
 
 pkgname=polymc
-pkgver=6.1
-pkgrel=0.1
+pkgver=7.0
+pkgrel=1
 pkgdesc="Minecraft launcher with ability to manage multiple instances."
 arch=('amd64')
 url="https://github.com/PolyMC/PolyMC"
 license=('GPL3')
-depends=('libqt5svg5' 'qt5-image-formats-plugins' 'libqt5xml5' 'libqt5core5a' 'libqt5network5' 'libqt5gui5' 'libqt5charts5-dev')
+depends=('hicolor-icon-theme' 'openjdk-21-jre' 'libgl-dev' 'qt6-base-dev' 'qt6-5compat-dev' 
+         'qt6-svg-dev' 'qt6-image-formats-plugins' 'qt6-charts-dev' 'libqt6charts6' 
+         'libqt6core5compat6' 'libqt6core6t64' 'libqt6gui6t64' 'libqt6network6t64' 
+         'libqt6networkauth6' 'libqt6svg6' 'libqt6xml6t64' 'libquazip1-qt6-dev' 'zlib1g-dev' 
+         'libgl-dev' 'libglvnd-dev')
 provides=('polymc')
 conflicts=('polymc')
-makedepends=('scdoc' 'extra-cmake-modules' 'cmake' 'git' 'openjdk-17-jdk' 'zlib1g-dev' 'libgl1-mesa-dev' 'qtbase5-dev' 'qtchooser' 'qt5-qmake' 'qtbase5-dev-tools' 'gcc' 'g++')
-optdepends=('java-runtime=8: support for Minecraft versions < 1.17'
-            'java-runtime=17: support for Minecraft versions >= 1.17')	    
+makedepends=('scdoc' 'extra-cmake-modules' 'cmake' 'git' 'openjdk-21-jdk' 'qtchooser' 
+             'qmake6' 'qmake6-bin' 'qt6-tools-dev-tools' 'qt6-tools-dev' 'gcc' 'g++')
+optdepends=('glfw: to use system GLFW libraries'
+            'openal: to use system OpenAL libraries'
+            'visualvm: Profiling support'
+            'xorg-xrandr: for older minecraft versions'
+            'java-runtime=8: support for Minecraft versions < 1.17'
+            'java-runtime=17: support for Minecraft versions >= 1.17'
+            'java-runtime=21: support for Minecraft versions >= 1.20')
+
 source=("https://github.com/PolyMC/PolyMC/releases/download/$pkgver/PolyMC-$pkgver.tar.gz")
 
-sha256sums=("16d62604f7e4aed0a9a31876b860e5054ca12e1c81fe47e74324eb1edec9d8d0")
+sha256sums=('e08e9a25f87db7da422351d044b330e4b1a568f3adabc04c388dc9e4f60c4701')
 
 build() {
 
-  cmake -DCMAKE_BUILD_TYPE= \
+  cmake -DCMAKE_BUILD_TYPE= 'None'\
     -DCMAKE_INSTALL_PREFIX="/usr" \
-    -DLauncher_QT_VERSION_MAJOR=5 \
-    -Bbuild -SPolyMC-$pkgver
+    -DLauncher_BUILD_PLATFORM='debianlinux' \
+    -DLauncher_QT_VERSION_MAJOR=6 \
+    -U_FORTIFY_SOURCE \
+    -D_FORTIFY_SOURCE=2 \
+    -Bbuild -SPolyMC-$pkgver \
+    -Wno-dev
+
   cmake --build build
 }
 


### PR DESCRIPTION
The following distros have updates available:
- `ubuntu-focal:amd64`
- `ubuntu-jammy:amd64`
- `ubuntu-noble:amd64`
- `ubuntu-oracular:amd64`
- `debian-bullseye:amd64`
- `debian-bookworm:amd64`

Depending on previously failed builds or newly added distros, there may not be any file changes in this PR. If, however, this information doesn't appear to be correct, please reach out to a Prebuilt-MPR team member.