### PR TITLE
Package Update: `code-bin`

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Hunter Wittenborn <hunter@hunterwittenborn.com>
 pkgname='code-bin'
-pkgver='1.99.0'
+pkgver='1.101.0'
 pkgrel='1'
 pkgdesc="Code editing. Redefined."
 arch=('amd64')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Hunter Wittenborn <hunter@hunterwittenborn.com>
 pkgname='code-bin'
-pkgver='1.97.2'
+pkgver='1.99.0'
 pkgrel='1'
 pkgdesc="Code editing. Redefined."
 arch=('amd64')


### PR DESCRIPTION
The following distros have updates available:
- `ubuntu-focal:amd64`
- `ubuntu-jammy:amd64`
- `ubuntu-noble:amd64`
- `ubuntu-oracular:amd64`
- `ubuntu-plucky:amd64`
- `debian-bullseye:amd64`
- `debian-bookworm:amd64`

Depending on previously failed builds or newly added distros, there may not be any file changes in this PR. If, however, this information doesn't appear to be correct, please reach out to a Prebuilt-MPR team member.