### PR TITLE
Package Update: `discord`

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,7 @@
 # Contributor: Hunter Wittenborn <hunter@hunterwittenborn.com>
 
 pkgname='discord'
-pkgver='0.0.97'
+pkgver='0.0.102'
 pkgrel='1'
 pkgdesc="Chat for Communities and Friends"
 arch=('amd64')
@@ -14,7 +14,7 @@ optdepends=('libappindicator1: Allow the app do display a menu in the system tra
 url="https://discord.com"
 license=('custom')
 source=("${pkgname}::https://dl.discordapp.net/apps/linux/${pkgver}/discord-${pkgver}.deb")
-b2sums=('c50b2dd48f0ddc03759fbddbbe0edbfb4708a967180b2aa43c871ec14350f547f10c5b8ef74fd196bfa7974b34f46be40bbffb4cd7cfa0f6ce29c7863a57e478')
+b2sums=('b8a875d03a013dc0deefc84be6e3b478d60ce8d11194a05e3764ca44493ac89d547ad51679c1f6f841672e0186b6c01bbf9113497fd7beebec6d3951e61aafd6')
 
 package() {
     tar -xf 'control.tar.gz'


### PR DESCRIPTION
The following distros have updates available:
- `ubuntu-focal:amd64`
- `ubuntu-jammy:amd64`
- `ubuntu-noble:amd64`
- `ubuntu-oracular:amd64`
- `ubuntu-plucky:amd64`
- `debian-bullseye:amd64`
- `debian-bookworm:amd64`

Depending on previously failed builds or newly added distros, there may not be any file changes in this PR. If, however, this information doesn't appear to be correct, please reach out to a Prebuilt-MPR team member.