### PR TITLE
Package Update: `starship`

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,10 +1,10 @@
 # Maintainer: Hunter Wittenborn <hunter@hunterwittenborn.com>
 pkgname=starship
-pkgver=1.10.2
+pkgver=1.21.1
 pkgrel=1
 pkgdesc='The minimal, blazing-fast, and infinitely customizable prompt for any shell!'
 arch=('any')
-makedepends=('cargo')
+makedepends=('cargo' 'cmake')
 url='https://starship.rs'
 
 source=("${pkgname}-${pkgver}::git+https://github.com/starship/starship/#tag=v${pkgver}")


### PR DESCRIPTION
The following distros have updates available:
- `ubuntu-focal:amd64`
- `ubuntu-focal:arm64`
- `ubuntu-jammy:amd64`
- `ubuntu-jammy:arm64`
- `ubuntu-noble:amd64`
- `ubuntu-noble:arm64`
- `ubuntu-oracular:amd64`
- `ubuntu-oracular:arm64`
- `ubuntu-plucky:amd64`
- `ubuntu-plucky:arm64`
- `debian-bullseye:amd64`
- `debian-bullseye:arm64`
- `debian-bookworm:amd64`
- `debian-bookworm:arm64`

Depending on previously failed builds or newly added distros, there may not be any file changes in this PR. If, however, this information doesn't appear to be correct, please reach out to a Prebuilt-MPR team member.